### PR TITLE
Use DPCPP include directory from find_program, update level_zero.hpp …

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -41,9 +41,13 @@ find_program(DPCPP_EXECUTABLE NAMES dpcpp
 
 if(DPCPP_EXECUTABLE)
 	get_filename_component(DPCPP_CORE_BINDIR ${DPCPP_EXECUTABLE} DIRECTORY)
-	get_filename_component(DPCPP_CORE_LIBDIR "${DPCPP_CORE_BINDIR}/../../linux/compiler/lib/intel64_lin" ABSOLUTE)
-	get_filename_component(DPCPP_SYCL_LIBDIR "${DPCPP_CORE_BINDIR}/../../linux/lib" ABSOLUTE)
+	get_filename_component(DPCPP_CORE_LIBDIR "${DPCPP_CORE_BINDIR}/../lib" ABSOLUTE)
+  get_filename_component(DPCPP_INCLUDE_DIR "${DPCPP_CORE_BINDIR}/../include" ABSOLUTE)
 endif()
+
+message(STATUS "DPCPP_CORE_BINDIR: ${DPCPP_CORE_BINDIR}")
+message(STATUS "DPCPP_CORE_LIBDIR: ${DPCPP_CORE_LIBDIR}")
+message(STATUS "DPCPP_INCLUDE_DIR: ${DPCPP_INCLUDE_DIR}")
 
 # the ENABLE_OMP_OFFLOAD is only required to unhide MKL::sycl in intel's MKLConfig.cmake file
 set(ENABLE_OMP_OFFLOAD ON)
@@ -53,7 +57,7 @@ find_package(MKL CONFIG
 	HINTS $ENV{MKLROOT}/lib/cmake/mkl  $ENV{ONEAPI_ROOT}/mkl/latest/lib/cmake/mkl
 	PATHS /opt/intel/oneapi/mkl/latest/lib/cmake/mkl)
 
-# message(STATUS "DPCPP : ${DPCPP_EXECUTABLE} MKL: ${MKL_FOUND} ")
+message(STATUS "DPCPP : ${DPCPP_EXECUTABLE} MKL: ${MKL_FOUND} ")
 
 if(DPCPP_EXECUTABLE AND MKL_FOUND)
   message(STATUS "Found both MLK and DPCPP")

--- a/library/src/oneApi_detail/deps/CMakeLists.txt
+++ b/library/src/oneApi_detail/deps/CMakeLists.txt
@@ -1,13 +1,14 @@
-set(CMAKE_CXX_COMPILER ${ICPX_EXECUTABLE})
+set(CMAKE_CXX_COMPILER icpx)
 set(CMAKE_CXX_FLAGS "-Wno-deprecated-declarations")
 set(POSITION_INDEPENDENT_CODE ON)
 
 add_library(sycl_wrapper SHARED ./sycl_wrapper.cpp)
 
+#message(STATUS "DPCPP_SYCL_INCUDE_DIR: ${DPCPP_INCLUDE_DIR}")
 target_link_libraries(sycl_wrapper PUBLIC MKL::MKL mkl_sycl MKL::mkl_intel_ilp64 MKL::mkl_sequential MKL::mkl_core)
 target_include_directories(sycl_wrapper
+                            PUBLIC  $<BUILD_INTERFACE:${DPCPP_INCLUDE_DIR}/sycl>
+                            PUBLIC  $<BUILD_INTERFACE:${DPCPP_INCLUDE_DIR}>
                             PUBLIC  $<BUILD_INTERFACE:~/packages>
-                            PUBLIC  $<BUILD_INTERFACE:/opt/intel/oneapi/compiler/latest/linux/include/sycl>
-                            PUBLIC  $<BUILD_INTERFACE:/opt/intel/oneapi/compiler/2022.2.1/linux/include>
                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/.. "$<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>")
 target_compile_options(sycl_wrapper PRIVATE "$<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>")

--- a/library/src/oneApi_detail/deps/CMakeLists.txt
+++ b/library/src/oneApi_detail/deps/CMakeLists.txt
@@ -2,7 +2,7 @@ set(CMAKE_CXX_COMPILER icpx)
 set(CMAKE_CXX_FLAGS "-Wno-deprecated-declarations")
 set(POSITION_INDEPENDENT_CODE ON)
 
-add_library(sycl_wrapper SHARED ./sycl_wrapper.cpp)
+add_library(sycl_wrapper SHARED ./sycl_wrapper.cpp ./onemkl.cpp ./sycl.cpp)
 
 #message(STATUS "DPCPP_SYCL_INCUDE_DIR: ${DPCPP_INCLUDE_DIR}")
 target_link_libraries(sycl_wrapper PUBLIC MKL::MKL mkl_sycl MKL::mkl_intel_ilp64 MKL::mkl_sequential MKL::mkl_core)
@@ -10,5 +10,7 @@ target_include_directories(sycl_wrapper
                             PUBLIC  $<BUILD_INTERFACE:${DPCPP_INCLUDE_DIR}/sycl>
                             PUBLIC  $<BUILD_INTERFACE:${DPCPP_INCLUDE_DIR}>
                             PUBLIC  $<BUILD_INTERFACE:~/packages>
+                            PRIVATE ${PROJECT_BINARY_DIR}/include/hipblas
+                            PRIVATE $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/.. "$<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>")
 target_compile_options(sycl_wrapper PRIVATE "$<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>")

--- a/library/src/oneApi_detail/deps/onemkl.cpp
+++ b/library/src/oneApi_detail/deps/onemkl.cpp
@@ -1,0 +1,347 @@
+#include "onemkl.h"
+#include "sycl.hpp"
+
+#include <oneapi/mkl.hpp>
+
+// This is a workaround to flush MKL submissions into Level-zero queue, 
+// using unspecified but guaranteed behavior of intel-sycl runtime. 
+// Once SYCL standard committee approves sycl::queue::flush() we will change the macro to use the same 
+#define __FORCE_MKL_FLUSH__(cmd) \
+            get_native<sycl::backend::ext_oneapi_level_zero>(cmd)
+
+// gemm
+
+// https://spec.oneapi.io/versions/1.0-rev-1/elements/oneMKL/source/domains/blas/gemm.html
+
+oneapi::mkl::transpose convert(onemklTranspose val) {
+    switch (val) {
+    case ONEMKL_TRANSPOSE_NONTRANS:
+        return oneapi::mkl::transpose::nontrans;
+    case ONEMKL_TRANSPOSE_TRANS:
+        return oneapi::mkl::transpose::trans;
+    case ONEMLK_TRANSPOSE_CONJTRANS:
+        return oneapi::mkl::transpose::conjtrans;
+    }
+}
+
+extern "C" int onemklHgemm(syclQueue_t device_queue, onemklTranspose transA,
+                           onemklTranspose transB, int64_t m, int64_t n,
+                           int64_t k, sycl::half alpha, const sycl::half *A, int64_t lda,
+                           const sycl::half *B, int64_t ldb, sycl::half beta, sycl::half *C,
+                           int64_t ldc) {
+    oneapi::mkl::blas::column_major::gemm(device_queue->val, convert(transA),
+                                          convert(transB), m, n, k, alpha, A,
+                                          lda, B, ldb, beta, C, ldc);
+    return 0;
+}
+
+extern "C" int onemklSgemm(syclQueue_t device_queue, onemklTranspose transA,
+                           onemklTranspose transB, int64_t m, int64_t n,
+                           int64_t k, float alpha, const float *A, int64_t lda,
+                           const float *B, int64_t ldb, float beta, float *C,
+                           int64_t ldc) {
+    oneapi::mkl::blas::column_major::gemm(device_queue->val, convert(transA),
+                                          convert(transB), m, n, k, alpha, A,
+                                          lda, B, ldb, beta, C, ldc);
+    return 0;
+}
+
+extern "C" int onemklDgemm(syclQueue_t device_queue, onemklTranspose transA,
+                           onemklTranspose transB, int64_t m, int64_t n,
+                           int64_t k, double alpha, const double *A,
+                           int64_t lda, const double *B, int64_t ldb,
+                           double beta, double *C, int64_t ldc) {
+    oneapi::mkl::blas::column_major::gemm(device_queue->val, convert(transA),
+                                          convert(transB), m, n, k, alpha, A,
+                                          lda, B, ldb, beta, C, ldc);
+    return 0;
+}
+
+extern "C" int onemklCgemm(syclQueue_t device_queue, onemklTranspose transA,
+                           onemklTranspose transB, int64_t m, int64_t n,
+                           int64_t k, float _Complex alpha,
+                           const float _Complex *A, int64_t lda,
+                           const float _Complex *B, int64_t ldb,
+                           float _Complex beta, float _Complex *C,
+                           int64_t ldc) {
+    oneapi::mkl::blas::column_major::gemm(
+        device_queue->val, convert(transA), convert(transB), m, n, k, alpha,
+        reinterpret_cast<const std::complex<float> *>(A), lda,
+        reinterpret_cast<const std::complex<float> *>(B), ldb, beta,
+        reinterpret_cast<std::complex<float> *>(C), ldc);
+    return 0;
+}
+
+extern "C" int onemklZgemm(syclQueue_t device_queue, onemklTranspose transA,
+                           onemklTranspose transB, int64_t m, int64_t n,
+                           int64_t k, double _Complex alpha,
+                           const double _Complex *A, int64_t lda,
+                           const double _Complex *B, int64_t ldb,
+                           double _Complex beta, double _Complex *C,
+                           int64_t ldc) {
+    oneapi::mkl::blas::column_major::gemm(
+        device_queue->val, convert(transA), convert(transB), m, n, k, alpha,
+        reinterpret_cast<const std::complex<double> *>(A), lda,
+        reinterpret_cast<const std::complex<double> *>(B), ldb, beta,
+        reinterpret_cast<std::complex<double> *>(C), ldc);
+    return 0;
+}
+
+extern "C" void onemklSasum(syclQueue_t device_queue, int64_t n, 
+                            const float *x, int64_t incx,
+                            float *result) {
+    auto status = oneapi::mkl::blas::column_major::asum(device_queue->val, n, x,
+                                                        incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDasum(syclQueue_t device_queue, int64_t n,
+                            const double *x, int64_t incx,
+                            double *result) {
+    auto status = oneapi::mkl::blas::column_major::asum(device_queue->val, n, x,
+                                                        incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCasum(syclQueue_t device_queue, int64_t n,
+                            const float _Complex *x, int64_t incx,
+                            float *result) {
+    auto status = oneapi::mkl::blas::column_major::asum(device_queue->val, n, 
+                                        reinterpret_cast<const std::complex<float> *>(x),
+                                        incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZasum(syclQueue_t device_queue, int64_t n,
+                            const double _Complex *x, int64_t incx,
+                            double *result) {
+    auto status = oneapi::mkl::blas::column_major::asum(device_queue->val, n, 
+                                        reinterpret_cast<const std::complex<double> *>(x),
+                                        incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklSaxpy(syclQueue_t device_queue, int64_t n, float alpha,
+                            const float *x, std::int64_t incx, float *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::axpy(device_queue->val, n, alpha, x,
+                                                incx, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDaxpy(syclQueue_t device_queue, int64_t n, double alpha, 
+                            const double *x, std::int64_t incx, double *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::axpy(device_queue->val, n, alpha, x,
+                                                incx, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCaxpy(syclQueue_t device_queue, int64_t n, float _Complex alpha,
+                        const float _Complex *x, std::int64_t incx, float _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::axpy(device_queue->val, n, alpha,
+                            reinterpret_cast<const std::complex<float> *>(x), incx,
+                            reinterpret_cast<std::complex<float> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZaxpy(syclQueue_t device_queue, int64_t n, double _Complex alpha,
+                        const double _Complex *x, std::int64_t incx, double _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::axpy(device_queue->val, n, alpha,
+                            reinterpret_cast<const std::complex<double> *>(x), incx,
+                            reinterpret_cast<std::complex<double> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+// Support Level-1: SCAL primitive
+extern "C" void onemklDscal(syclQueue_t device_queue, int64_t n, double alpha,
+                            double *x, int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::scal(device_queue->val, n, alpha,
+                                                    x, incx);
+    __FORCE_MKL_FLUSH__(status);
+
+}
+
+extern "C" void onemklSscal(syclQueue_t device_queue, int64_t n, float alpha,
+                            float *x, int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::scal(device_queue->val, n, alpha,
+                                                         x, incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCscal(syclQueue_t device_queue, int64_t n,
+                            float _Complex alpha, float _Complex *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::scal(device_queue->val, n,
+                                        static_cast<std::complex<float> >(alpha),
+                                        reinterpret_cast<std::complex<float> *>(x),incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCsscal(syclQueue_t device_queue, int64_t n,
+                            float alpha, float _Complex *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::scal(device_queue->val, n, alpha,
+                                        reinterpret_cast<std::complex<float> *>(x),incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZscal(syclQueue_t device_queue, int64_t n,
+                            double _Complex alpha, double _Complex *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::scal(device_queue->val, n,
+                                        static_cast<std::complex<double> >(alpha),
+                                        reinterpret_cast<std::complex<double> *>(x),incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZdscal(syclQueue_t device_queue, int64_t n,
+                            double alpha, double _Complex *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::scal(device_queue->val, n, alpha,
+                                        reinterpret_cast<std::complex<double> *>(x),incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDnrm2(syclQueue_t device_queue, int64_t n, const double *x, 
+                            int64_t incx, double *result) {
+    auto status = oneapi::mkl::blas::column_major::nrm2(device_queue->val, n, x, incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklSnrm2(syclQueue_t device_queue, int64_t n, const float *x, 
+                            int64_t incx, float *result) {
+    auto status = oneapi::mkl::blas::column_major::nrm2(device_queue->val, n, x, incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCnrm2(syclQueue_t device_queue, int64_t n, const float _Complex *x, 
+                            int64_t incx, float *result) {   
+    auto status = oneapi::mkl::blas::column_major::nrm2(device_queue->val, n, 
+                    reinterpret_cast<const std::complex<float> *>(x), incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZnrm2(syclQueue_t device_queue, int64_t n, const double _Complex *x, 
+                            int64_t incx, double *result) {
+    auto status = oneapi::mkl::blas::column_major::nrm2(device_queue->val, n, 
+                    reinterpret_cast<const std::complex<double> *>(x), incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDcopy(syclQueue_t device_queue, int64_t n, const double *x,
+                            int64_t incx, double *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::copy(device_queue->val, n, x, incx, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklScopy(syclQueue_t device_queue, int64_t n, const float *x,
+                            int64_t incx, float *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::copy(device_queue->val, n, x, incx, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZcopy(syclQueue_t device_queue, int64_t n, const double _Complex *x,
+                            int64_t incx, double _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::copy(device_queue->val, n,
+        reinterpret_cast<const std::complex<double> *>(x), incx,
+        reinterpret_cast<std::complex<double> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCcopy(syclQueue_t device_queue, int64_t n, const float _Complex *x,
+                            int64_t incx, float _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::copy(device_queue->val, n, 
+        reinterpret_cast<const std::complex<float> *>(x), incx, 
+        reinterpret_cast<std::complex<float> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDamax(syclQueue_t device_queue, int64_t n, const double *x,
+                            int64_t incx, int64_t *result){
+    auto status = oneapi::mkl::blas::column_major::iamax(device_queue->val, n, x, incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+extern "C" void onemklSamax(syclQueue_t device_queue, int64_t n, const float  *x,
+                            int64_t incx, int64_t *result){
+    auto status = oneapi::mkl::blas::column_major::iamax(device_queue->val, n, x, incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+extern "C" void onemklZamax(syclQueue_t device_queue, int64_t n, const double _Complex *x,
+                            int64_t incx, int64_t *result){
+    auto status = oneapi::mkl::blas::column_major::iamax(device_queue->val, n,
+                            reinterpret_cast<const std::complex<double> *>(x), incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+extern "C" void onemklCamax(syclQueue_t device_queue, int64_t n, const float _Complex *x,
+                            int64_t incx, int64_t *result){
+    auto status = oneapi::mkl::blas::column_major::iamax(device_queue->val, n,
+                            reinterpret_cast<const std::complex<float> *>(x), incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDamin(syclQueue_t device_queue, int64_t n, const double *x,
+                            int64_t incx, int64_t *result){
+    auto status = oneapi::mkl::blas::column_major::iamin(device_queue->val, n, x, incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+extern "C" void onemklSamin(syclQueue_t device_queue, int64_t n, const float  *x,
+                            int64_t incx, int64_t *result){
+    auto status = oneapi::mkl::blas::column_major::iamin(device_queue->val, n, x, incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+extern "C" void onemklZamin(syclQueue_t device_queue, int64_t n, const double _Complex *x,
+                            int64_t incx, int64_t *result){
+    auto status = oneapi::mkl::blas::column_major::iamin(device_queue->val, n,
+                            reinterpret_cast<const std::complex<double> *>(x), incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+extern "C" void onemklCamin(syclQueue_t device_queue, int64_t n, const float _Complex *x,
+                            int64_t incx, int64_t *result){
+    auto status = oneapi::mkl::blas::column_major::iamin(device_queue->val, n,
+                            reinterpret_cast<const std::complex<float> *>(x), incx, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklSswap(syclQueue_t device_queue, int64_t n, float *x, int64_t incx,\
+                            float *y, int64_t incy){
+    auto status = oneapi::mkl::blas::column_major::swap(device_queue->val, n, x, incx, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDswap(syclQueue_t device_queue, int64_t n, double *x, int64_t incx,
+                            double *y, int64_t incy){
+    auto status = oneapi::mkl::blas::column_major::swap(device_queue->val, n, x, incx, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCswap(syclQueue_t device_queue, int64_t n, float _Complex *x, int64_t incx,
+                            float _Complex *y, int64_t incy){
+    auto status = oneapi::mkl::blas::column_major::swap(device_queue->val, n,
+                            reinterpret_cast<std::complex<float> *>(x), incx,
+                            reinterpret_cast<std::complex<float> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZswap(syclQueue_t device_queue, int64_t n, double _Complex *x, int64_t incx,
+                            double _Complex *y, int64_t incy){
+    auto status = oneapi::mkl::blas::column_major::swap(device_queue->val, n,
+                            reinterpret_cast<std::complex<double> *>(x), incx,
+                            reinterpret_cast<std::complex<double> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+// other
+
+// oneMKL keeps a cache of SYCL queues and tries to destroy them when unloading the library.
+// that is incompatible with oneAPI.jl destroying queues before that, so expose a function
+// to manually wipe the device cache when we're destroying queues.
+
+namespace oneapi {
+namespace mkl {
+namespace gpu {
+int clean_gpu_caches();
+}
+}
+}
+
+extern "C" void onemklDestroy() {
+    oneapi::mkl::gpu::clean_gpu_caches();
+}

--- a/library/src/oneApi_detail/deps/onemkl.h
+++ b/library/src/oneApi_detail/deps/onemkl.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include "sycl.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    ONEMKL_TRANSPOSE_NONTRANS,
+    ONEMKL_TRANSPOSE_TRANS,
+    ONEMLK_TRANSPOSE_CONJTRANS
+} onemklTranspose;
+
+// XXX: how to expose half in C?
+// int onemklHgemm(syclQueue_t device_queue, onemklTranspose transA,
+//                onemklTranspose transB, int64_t m, int64_t n, int64_t k,
+//                half alpha, const half *A, int64_t lda, const half *B,
+//                int64_t ldb, half beta, half *C, int64_t ldc);
+int onemklSgemm(syclQueue_t device_queue, onemklTranspose transA,
+                onemklTranspose transB, int64_t m, int64_t n, int64_t k,
+                float alpha, const float *A, int64_t lda, const float *B,
+                int64_t ldb, float beta, float *C, int64_t ldc);
+int onemklDgemm(syclQueue_t device_queue, onemklTranspose transA,
+                onemklTranspose transB, int64_t m, int64_t n, int64_t k,
+                double alpha, const double *A, int64_t lda, const double *B,
+                int64_t ldb, double beta, double *C, int64_t ldc);
+int onemklCgemm(syclQueue_t device_queue, onemklTranspose transA,
+                onemklTranspose transB, int64_t m, int64_t n, int64_t k,
+                float _Complex alpha, const float _Complex *A, int64_t lda,
+                const float _Complex *B, int64_t ldb, float _Complex beta,
+                float _Complex *C, int64_t ldc);
+int onemklZgemm(syclQueue_t device_queue, onemklTranspose transA,
+                onemklTranspose transB, int64_t m, int64_t n, int64_t k,
+                double _Complex alpha, const double _Complex *A, int64_t lda,
+                const double _Complex *B, int64_t ldb, double _Complex beta,
+                double _Complex *C, int64_t ldc);
+
+void onemklSasum(syclQueue_t device_queue, int64_t n,
+                const float *x, int64_t incx, float *result);
+void onemklDasum(syclQueue_t device_queue, int64_t n,
+                const double *x, int64_t incx, double *result);
+void onemklCasum(syclQueue_t device_queue, int64_t n,
+                const float _Complex *x, int64_t incx, float *result);
+void onemklZasum(syclQueue_t device_queue, int64_t n,
+                const double _Complex *x, int64_t incx, double *result);
+
+void onemklSaxpy(syclQueue_t device_queue, int64_t n, float alpha, const float *x,
+                int64_t incx, float *y, int64_t incy);
+void onemklDaxpy(syclQueue_t device_queue, int64_t n, double alpha, const double *x,
+                int64_t incx, double *y, int64_t incy);
+void onemklCaxpy(syclQueue_t device_queue, int64_t n, float _Complex alpha,
+                const float _Complex *x, int64_t incx, float _Complex *y, int64_t incy);
+void onemklZaxpy(syclQueue_t device_queue, int64_t n, double _Complex alpha,
+                const double _Complex *x, int64_t incx, double _Complex *y, int64_t incy);
+
+// Level-1: scal oneMKL
+void onemklDscal(syclQueue_t device_queue, int64_t n, double alpha, 
+                double *x, int64_t incx);
+void onemklSscal(syclQueue_t device_queue, int64_t n, float alpha, 
+                float *x, int64_t incx);
+void onemklCscal(syclQueue_t device_queue, int64_t n, float _Complex alpha, 
+                float _Complex *x, int64_t incx);
+void onemklCsscal(syclQueue_t device_queue, int64_t n, float alpha, 
+                float _Complex *x, int64_t incx);
+void onemklZscal(syclQueue_t device_queue, int64_t n, double _Complex alpha, 
+                double _Complex *x, int64_t incx);
+void onemklZdscal(syclQueue_t device_queue, int64_t n, double alpha, 
+                double _Complex *x, int64_t incx);
+// Supported Level-1: Nrm2
+void onemklDnrm2(syclQueue_t device_queue, int64_t n, const double *x, 
+                 int64_t incx, double *result);
+void onemklSnrm2(syclQueue_t device_queue, int64_t n, const float *x, 
+                 int64_t incx, float *result);
+void onemklCnrm2(syclQueue_t device_queue, int64_t n, const float _Complex *x, 
+                 int64_t incx, float *result);
+void onemklZnrm2(syclQueue_t device_queue, int64_t n, const double _Complex *x, 
+                 int64_t incx, double *result);
+
+void onemklDcopy(syclQueue_t device_queue, int64_t n, const double *x,
+                 int64_t incx, double *y, int64_t incy);
+void onemklScopy(syclQueue_t device_queue, int64_t n, const float *x,
+                 int64_t incx, float *y, int64_t incy);
+void onemklZcopy(syclQueue_t device_queue, int64_t n, const double _Complex *x,
+                 int64_t incx, double _Complex *y, int64_t incy);
+void onemklCcopy(syclQueue_t device_queue, int64_t n, const float _Complex *x,
+                 int64_t incx, float _Complex *y, int64_t incy);
+
+void onemklDamax(syclQueue_t device_queue, int64_t n, const double *x, int64_t incx,
+                 int64_t *result);
+void onemklSamax(syclQueue_t device_queue, int64_t n, const float  *x, int64_t incx,
+                 int64_t *result);
+void onemklZamax(syclQueue_t device_queue, int64_t n, const double _Complex *x, int64_t incx,
+                 int64_t *result);
+void onemklCamax(syclQueue_t device_queue, int64_t n, const float _Complex *x, int64_t incx,
+                 int64_t *result);
+
+void onemklDamin(syclQueue_t device_queue, int64_t n, const double *x, int64_t incx,
+                 int64_t *result);
+void onemklSamin(syclQueue_t device_queue, int64_t n, const float  *x, int64_t incx,
+                 int64_t *result);
+void onemklZamin(syclQueue_t device_queue, int64_t n, const double _Complex *x, int64_t incx,
+                 int64_t *result);
+void onemklCamin(syclQueue_t device_queue, int64_t n, const float _Complex *x, int64_t incx,
+                 int64_t *result);
+
+void onemklSswap(syclQueue_t device_queue, int64_t n, float *x, int64_t incx,
+                float *y, int64_t incy);
+void onemklDswap(syclQueue_t device_queue, int64_t n, double *x, int64_t incx,
+                double *y, int64_t incy);
+void onemklCswap(syclQueue_t device_queue, int64_t n, float _Complex *x, int64_t incx,
+                float _Complex *y, int64_t incy);
+void onemklZswap(syclQueue_t device_queue, int64_t n, double _Complex *x, int64_t incx,
+                double _Complex *y, int64_t incy);
+
+void onemklDestroy();
+#ifdef __cplusplus
+}
+#endif

--- a/library/src/oneApi_detail/deps/sycl.cpp
+++ b/library/src/oneApi_detail/deps/sycl.cpp
@@ -1,0 +1,74 @@
+#include "sycl.hpp"
+
+#include <sycl/ext/oneapi/backend/level_zero.hpp>
+
+// https://github.com/intel/llvm/blob/sycl/sycl/include/sycl/ext/oneapi/backend/level_zero.hpp
+
+extern "C" int syclPlatformCreate(syclPlatform_t *obj,
+                                  ze_driver_handle_t driver) {
+    auto sycl_platform = sycl::ext::oneapi::level_zero::make_platform((pi_native_handle) driver);
+    *obj = new syclPlatform_st({sycl_platform});
+    return 0;
+}
+
+extern "C" int syclPlatformDestroy(syclPlatform_t obj) {
+    delete obj;
+    return 0;
+}
+
+extern "C" int syclDeviceCreate(syclDevice_t *obj, syclPlatform_t platform,
+                                ze_device_handle_t device) {
+    auto sycl_device =
+        sycl::ext::oneapi::level_zero::make_device(platform->val, (pi_native_handle) device);
+    *obj = new syclDevice_st({sycl_device});
+    return 0;
+}
+
+extern "C" int syclDeviceDestroy(syclDevice_t obj) {
+    delete obj;
+    return 0;
+}
+
+extern "C" int syclContextCreate(syclContext_t *obj, syclDevice_t *devices,
+                                 size_t ndevices, ze_context_handle_t context,
+                                 int keep_ownership) {
+    std::vector<sycl::device> sycl_devices(ndevices);
+    for (size_t i = 0; i < ndevices; i++)
+        sycl_devices[i] = devices[i]->val;
+
+    auto sycl_context =
+        sycl::ext::oneapi::level_zero::make_context(sycl_devices, (pi_native_handle) context, keep_ownership);
+    *obj = new syclContext_st({sycl_context});
+    return 0;
+}
+
+extern "C" int syclContextDestroy(syclContext_t obj) {
+    delete obj;
+    return 0;
+}
+
+extern "C" int syclQueueCreate(syclQueue_t *obj, syclContext_t context,
+                               ze_command_queue_handle_t queue,
+                               int keep_ownership) {
+    // XXX: ownership argument only used on master
+    auto sycl_queue = sycl::ext::oneapi::level_zero::make_queue(context->val, (pi_native_handle) queue, keep_ownership);
+    *obj = new syclQueue_st({sycl_queue});
+    return 0;
+}
+
+extern "C" int syclQueueDestroy(syclQueue_t obj) {
+    delete obj;
+    return 0;
+}
+
+extern "C" int syclEventCreate(syclEvent_t *obj, syclContext_t context,
+                               ze_event_handle_t event, int keep_ownership) {
+   auto sycl_event = sycl::ext::oneapi::level_zero::make_event(context->val, (pi_native_handle) event, keep_ownership);
+   *obj = new syclEvent_st({sycl_event});
+   return 0;
+}
+
+extern "C" int syclEventDestroy(syclEvent_t obj) {
+   delete obj;
+   return 0;
+}

--- a/library/src/oneApi_detail/deps/sycl.h
+++ b/library/src/oneApi_detail/deps/sycl.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <stddef.h>
+
+#include <level_zero/ze_api.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct syclPlatform_st *syclPlatform_t;
+int syclPlatformCreate(syclPlatform_t *obj, ze_driver_handle_t driver);
+int syclPlatformDestroy(syclPlatform_t obj);
+
+typedef struct syclDevice_st *syclDevice_t;
+int syclDeviceCreate(syclDevice_t *obj, syclPlatform_t platform,
+                     ze_device_handle_t device);
+int syclDeviceDestroy(syclDevice_t obj);
+
+typedef struct syclContext_st *syclContext_t;
+int syclContextCreate(syclContext_t *obj, syclDevice_t *devices, size_t ndevices,
+                      ze_context_handle_t context, int keep_ownership);
+int syclContextDestroy(syclContext_t obj);
+
+typedef struct syclQueue_st *syclQueue_t;
+int syclQueueCreate(syclQueue_t *obj, syclContext_t context,
+                    ze_command_queue_handle_t queue, int keep_ownership);
+int syclQueueDestroy(syclQueue_t obj);
+
+typedef struct syclEvent_st *syclEvent_t;
+int syclEventCreate(syclEvent_t *obj, syclContext_t context,
+                    ze_event_handle_t event, int keep_ownership);
+int syclEventDestroy(syclEvent_t obj);
+
+#ifdef __cplusplus
+}
+#endif

--- a/library/src/oneApi_detail/deps/sycl.hpp
+++ b/library/src/oneApi_detail/deps/sycl.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "sycl.h"
+
+#include <CL/sycl.hpp>
+
+struct syclPlatform_st {
+    sycl::platform val;
+};
+
+struct syclDevice_st {
+    sycl::device val;
+};
+
+struct syclContext_st {
+    sycl::context val;
+};
+
+struct syclQueue_st {
+    sycl::queue val;
+};
+
+struct syclEvent_st {
+    sycl::event val;
+};

--- a/library/src/oneApi_detail/deps/sycl_wrapper.cpp
+++ b/library/src/oneApi_detail/deps/sycl_wrapper.cpp
@@ -1,11 +1,11 @@
 #include <iostream>
 
-#include "include/ze_api.h"
-#include "CL/sycl/backend/level_zero.hpp"
-#include "CL/sycl.hpp"
-#include "oneapi/mkl.hpp"
+#include <include/ze_api.h>
+#include <sycl.hpp>
+#include <ext/oneapi/backend/level_zero.hpp>
+#include <oneapi/mkl.hpp>
 
-#include <sycl_w.h>
+#include "sycl_w.h"
 
 void* get_current_context() {
 

--- a/library/src/oneApi_detail/deps/sycl_wrapper.cpp
+++ b/library/src/oneApi_detail/deps/sycl_wrapper.cpp
@@ -4,17 +4,105 @@
 #include <sycl.hpp>
 #include <ext/oneapi/backend/level_zero.hpp>
 #include <oneapi/mkl.hpp>
+#include "sycl.h"
+#include "sycl.hpp"
+
+#define __HIP_PLATFORM_SPIRV__
+#include "hipblas.h"
 
 #include "sycl_w.h"
 
-void* get_current_context() {
+struct syclblasHandle
+{
+    syclPlatform_t platform;
+    syclDevice_t   device;
+    syclContext_t  context;
+    syclQueue_t    queue;
+    hipStream_t    hip_stream;
 
+    syclblasHandle(void) :
+      platform(), device(), context(), queue(), hip_stream() {}
+    
+    ~syclblasHandle() {
+      syclQueueDestroy(queue);
+      syclContextDestroy(context);
+      syclDeviceDestroy(device);
+      syclPlatformDestroy(platform);
+    } 
+};
+
+hipblasStatus_t syclblasCreate(syclblasHandle_t* handle)
+{
+  if (handle != nullptr) {
+    auto res = new syclblasHandle();
+    // FIX Me:  needs to get the default NULL stream from HIP runtime to set  
+  }
+  return (handle != nullptr) ? HIPBLAS_STATUS_SUCCESS : HIPBLAS_STATUS_HANDLE_IS_NULLPTR;
 }
 
-void set_current_context() {
-
+hipblasStatus_t syclblasDestroy(syclblasHandle_t handle)
+{
+  if(handle != nullptr)
+  {
+    delete handle;
+  }
+  return (handle != nullptr) ? HIPBLAS_STATUS_SUCCESS : HIPBLAS_STATUS_HANDLE_IS_NULLPTR;
 }
 
-void print_me() {
-  std::cout<<"From sycl_wrapper library"<<std::endl;
+hipblasStatus_t syclblasSetStream(syclblasHandle_t     handle,
+                                  unsigned long const* lzHandles,
+                                  int                  nHandles,
+                                  hipStream_t          stream)
+{
+    if(handle != nullptr)
+    {
+        handle->hip_stream = stream;
+        // Obtain the handles to the LZ constructs.
+        assert(nHandles == 4);
+        auto hDriver  = (ze_driver_handle_t)lzHandles[0];
+        auto hDevice  = (ze_device_handle_t)lzHandles[1];
+        auto hContext = (ze_context_handle_t)lzHandles[2];
+        auto hQueue   = (ze_command_queue_handle_t)lzHandles[3];
+
+        // Build SYCL platform/device/queue from the LZ handles.
+        syclPlatformCreate(&handle->platform, hDriver);
+        syclDeviceCreate(&handle->device, handle->platform, hDevice);
+        // FIX ME: only 1 device is returned from CHIP-SPV's lzHandles
+        syclContextCreate(
+            &handle->context, &handle->device, 1 /*ndevices*/, hContext, 1 /*keep_ownership*/);
+        syclQueueCreate(&handle->queue, handle->context, hQueue, 1 /* keep ownership */);
+
+        auto asyncExceptionHandler = [](sycl::exception_list exceptions) {
+            // Report all asynchronous exceptions that occurred.
+            for(std::exception_ptr const& e : exceptions)
+            {
+                try
+                {
+                    std::rethrow_exception(e);
+                }
+                catch(std::exception& e)
+                {
+                    std::cerr << "Async exception: " << e.what() << std::endl;
+                }
+            }
+
+            // Rethrow the first asynchronous exception.
+            for(std::exception_ptr const& e : exceptions)
+            {
+                std::rethrow_exception(e);
+            }
+        };
+    }
+
+    return (handle != nullptr) ? HIPBLAS_STATUS_SUCCESS : HIPBLAS_STATUS_HANDLE_IS_NULLPTR;
+}
+
+syclQueue_t syclblasGetSyclQueue(syclblasHandle_t handle)
+{
+  return handle->queue;
+}
+
+void print_me()
+{
+    std::cout << "From sycl_wrapper library" << std::endl;
 }

--- a/library/src/oneApi_detail/hipblas.cpp
+++ b/library/src/oneApi_detail/hipblas.cpp
@@ -27,17 +27,57 @@
 #include <algorithm>
 #include <functional>
 #include "sycl_w.h"
+#include "deps/onemkl.h"
 //#include <math.h>
 
+using namepace oneapi;
+
+hipblasStatus_t
+hipblasCreate(hipblasHandle_t* handle)
+try
+{
+    return syclblasCreate((syclblasHandle_t*)handle));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t
+hipblasDestroy(hipblasHandle_t handle)
+try
+{
+    return syclblasDestroy((syclblasHandle_t)handle));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t
+hipblasSetStream(hipblasHandle_t handle, hipStream_t stream)
+try
+{
+    // Obtain the handles to the LZ handlers.
+    unsigned long lzHandles[4];
+    int           nHandles = 0;
+    hiplzStreamNativeInfo(stream, lzHandles, &nHandles);
+
+    return syclblasSetStream((syclblasHandle_t)handle, nHandles, lzHandles, stream);
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
 
 hipblasStatus_t
     hipblasScopy(hipblasHandle_t handle, int n, const float* x, int incx, float* y, int incy)
 try
 {
-    print_me(); // coming from sycl_wrapper 
-    // oneAPI call
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
-    //return rocBLASStatusToHIPStatus(rocblas_scopy((rocblas_handle)handle, n, x, incx, y, incy));
+    print_me(); // coming from sycl_wrapper
+
+    onemklScopy(syclblasGetSyclQueue((syclblasHandle_t) handle, n, x, incx, y, incy);  
+    return HIPBLAS_STATUS_SUCCESS;
 }
 catch(...)
 {

--- a/library/src/oneApi_detail/sycl_w.h
+++ b/library/src/oneApi_detail/sycl_w.h
@@ -1,3 +1,19 @@
+#pragma once
+
+#include <stddef.h>
+#include <level_zero/ze_api.h>
+
+#ifdef __cplusplus
 extern "C" {
-  void print_me();
+#endif
+
+typedef struct syclblasHandle *syclblasHandle_t;
+hipblasStatus_t syclblasCreate(syclblasHandle_t* handle);
+hipblasStatus_t syclblasDestroy(syclblasHandle_t handle);
+hipblasStatus_t syclblasSetStream(syclblasHandle_t handle, hipStream_t stream);
+
+void print_me();
+
+#ifdef __cplusplus
 }
+#endif


### PR DESCRIPTION
…path to the new ext directory

Summary of proposed changes:
- Get rid of the hard coded DPCPP include directory
- Fix the deprecated backend/level_zero.hpp usage

Please check if the change still works for your local setting and review.
