### PR TITLE
Small changes to avoid undefined types from hipblas.h

### DIFF
--- a/library/src/oneApi_detail/hipblas.cpp
+++ b/library/src/oneApi_detail/hipblas.cpp
@@ -23,13 +23,14 @@
 
 //#include <hip/hip_runtime.h>
 #include "deps/onemkl.h"
-#include "sycl_w.h"
 #include <algorithm>
-#include <exceptions.hpp>
 #include <functional>
 #include <hip/hip_interop.h>
 #include <hipblas.h>
+#include <exceptions.hpp>
 //#include <math.h>
+
+#include "sycl_w.h"
 
 // local functions
 static hipblasStatus_t updateSyclHandlesToCrrStream(hipStream_t stream, syclblasHandle_t handle)

--- a/library/src/oneApi_detail/sycl_w.h
+++ b/library/src/oneApi_detail/sycl_w.h
@@ -2,6 +2,7 @@
 
 #include "deps/onemkl.h"
 #include "deps/sycl.h"
+#include <hipblas.h>
 #include <level_zero/ze_api.h>
 #include <stddef.h>
 


### PR DESCRIPTION
Summary of proposed changes:
- include hipblas.h in sycl_w.h to bring in hipblasStatus_t
- move exceptions.h after hipblas.h to avoid undefined reference to hipblas status enum.

