### PR TITLE
Add level1 one mkl apis

### DIFF
--- a/library/src/oneApi_detail/deps/onemkl.cpp
+++ b/library/src/oneApi_detail/deps/onemkl.cpp
@@ -24,6 +24,24 @@ oneapi::mkl::transpose convert(onemklTranspose val) {
     }
 }
 
+oneapi::mkl::uplo convert(onemklUplo val) {
+    switch(val) {
+        case ONEMKL_UPLO_UPPER:
+            return oneapi::mkl::uplo::upper;
+        case ONEMKL_UPLO_LOWER:
+            return oneapi::mkl::uplo::lower;
+    }
+}
+
+oneapi::mkl::diag convert(onemklDiag val) {
+    switch(val) {
+        case ONEMKL_DIAG_NONUNIT:
+            return oneapi::mkl::diag::nonunit;
+        case ONEMKL_DIAG_UNIT:
+            return oneapi::mkl::diag::unit;
+    }
+}
+
 extern "C" int onemklHgemm(syclQueue_t device_queue, onemklTranspose transA,
                            onemklTranspose transB, int64_t m, int64_t n,
                            int64_t k, sycl::half alpha, const sycl::half *A, int64_t lda,

--- a/library/src/oneApi_detail/deps/onemkl.cpp
+++ b/library/src/oneApi_detail/deps/onemkl.cpp
@@ -87,6 +87,111 @@ extern "C" int onemklZgemm(syclQueue_t device_queue, onemklTranspose transA,
     return 0;
 }
 
+extern "C" void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, int64_t kl, int64_t ku,
+                            float alpha, const float *a, int64_t lda,
+                            const float *x, int64_t incx, float beta, float *y,
+                            int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gbmv(device_queue->val,
+                                convert(trans), m, n, kl, ku, alpha, a, lda, x,
+                                incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDgbmv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, int64_t kl, int64_t ku,
+                            double alpha, const double *a, int64_t lda,
+                            const double *x, int64_t incx, double beta, double *y,
+                            int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gbmv(device_queue->val, convert(trans),
+                                    m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCgbmv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, int64_t kl, int64_t ku,
+                            float _Complex alpha, const float _Complex *a, int64_t lda,
+                            const float _Complex *x, int64_t incx, float _Complex beta,
+                            float _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gbmv(device_queue->val, convert(trans),
+                                    m, n, kl, ku, static_cast<std::complex<float> >(alpha),
+                                    reinterpret_cast<const std::complex<float> *>(a),
+                                    lda, reinterpret_cast<const std::complex<float> *>(x),
+                                    incx, static_cast<std::complex<float> >(beta),
+                                    reinterpret_cast<std::complex<float> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZgbmv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, int64_t kl, int64_t ku,
+                            double _Complex alpha, const double _Complex *a, int64_t lda,
+                            const double _Complex *x, int64_t incx, double _Complex beta,
+                            double _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gbmv(device_queue->val, convert(trans), m,
+                                        n, kl, ku, static_cast<std::complex<double> >(alpha),
+                                        reinterpret_cast<const std::complex<double> *>(a),
+                                        lda, reinterpret_cast<const std::complex<double> *>(x), incx,
+                                        static_cast<std::complex<double> >(beta),
+                                        reinterpret_cast<std::complex<double> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklSdot(syclQueue_t device_queue, int64_t n,
+                           const float *x, int64_t incx, const float *y,
+                           int64_t incy, float *result) {
+    auto status = oneapi::mkl::blas::column_major::dot(device_queue->val, n, x,
+                                                       incx, y, incy, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDdot(syclQueue_t device_queue, int64_t n,
+                           const double *x, int64_t incx, const double *y,
+                           int64_t incy, double *result) {
+    auto status = oneapi::mkl::blas::column_major::dot(device_queue->val, n, x,
+                                                       incx, y, incy, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCdotc(syclQueue_t device_queue, int64_t n,
+                           const float _Complex *x, int64_t incx, const float _Complex *y,
+                           int64_t incy, float _Complex *result) {
+    auto status = oneapi::mkl::blas::column_major::dotc(device_queue->val, n,
+                                                reinterpret_cast<const std::complex<float> *>(x), incx,
+                                                reinterpret_cast<const std::complex<float> *>(y), incy,
+                                                reinterpret_cast<std::complex<float> *>(result));
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZdotc(syclQueue_t device_queue, int64_t n,
+                           const double _Complex *x, int64_t incx, const double _Complex *y,
+                           int64_t incy, double _Complex *result) {
+    auto status = oneapi::mkl::blas::column_major::dotc(device_queue->val, n,
+                                                reinterpret_cast<const std::complex<double> *>(x), incx,
+                                                reinterpret_cast<const std::complex<double> *>(y), incy,
+                                                reinterpret_cast<std::complex<double> *>(result));
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCdotu(syclQueue_t device_queue, int64_t n,
+                           const float _Complex *x, int64_t incx, const float _Complex *y,
+                           int64_t incy, float _Complex *result) {
+    auto status = oneapi::mkl::blas::column_major::dotu(device_queue->val, n,
+                                                reinterpret_cast<const std::complex<float> *>(x), incx,
+                                                reinterpret_cast<const std::complex<float> *>(y), incy,
+                                                reinterpret_cast<std::complex<float> *>(result));
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZdotu(syclQueue_t device_queue, int64_t n,
+                           const double _Complex *x, int64_t incx, const double _Complex *y,
+                           int64_t incy, double _Complex *result) {
+    auto status = oneapi::mkl::blas::column_major::dotu(device_queue->val, n,
+                                                reinterpret_cast<const std::complex<double> *>(x), incx,
+                                                reinterpret_cast<const std::complex<double> *>(y), incy,
+                                                reinterpret_cast<std::complex<double> *>(result));
+    __FORCE_MKL_FLUSH__(status);
+}
+
 extern "C" void onemklSasum(syclQueue_t device_queue, int64_t n, 
                             const float *x, int64_t incx,
                             float *result) {
@@ -150,6 +255,7 @@ extern "C" void onemklZaxpy(syclQueue_t device_queue, int64_t n, double _Complex
                             reinterpret_cast<std::complex<double> *>(y), incy);
     __FORCE_MKL_FLUSH__(status);
 }
+
 // Support Level-1: SCAL primitive
 extern "C" void onemklDscal(syclQueue_t device_queue, int64_t n, double alpha,
                             double *x, int64_t incx) {
@@ -197,6 +303,337 @@ extern "C" void onemklZdscal(syclQueue_t device_queue, int64_t n,
                             int64_t incx) {
     auto status = oneapi::mkl::blas::column_major::scal(device_queue->val, n, alpha,
                                         reinterpret_cast<std::complex<double> *>(x),incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+
+extern "C" void onemklSgemv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, float alpha, const float *a,
+                            int64_t lda, const float *x, int64_t incx, float beta,
+                            float *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gemv(device_queue->val, convert(trans),
+                                            m, n, alpha, a, lda, x, incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDgemv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, double alpha, const double *a,
+                            int64_t lda, const double *x, int64_t incx, double beta,
+                            double *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gemv(device_queue->val, convert(trans),
+                                            m, n, alpha, a, lda, x, incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCgemv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, float _Complex alpha,
+                            const float _Complex *a, int64_t lda,
+                            const float _Complex *x, int64_t incx,
+                            float _Complex beta, float _Complex *y,
+                            int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gemv(device_queue->val, convert(trans), m, n,
+                                            static_cast<std::complex<float> >(alpha),
+                                            reinterpret_cast<const std::complex<float> *>(a), lda,
+                                            reinterpret_cast<const std::complex<float> *>(x), incx,
+                                            static_cast<std::complex<float> >(beta),
+                                            reinterpret_cast<std::complex<float> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZgemv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, double _Complex alpha,
+                            const double _Complex *a, int64_t lda,
+                            const double _Complex *x, int64_t incx,
+                            double _Complex beta, double _Complex *y,
+                            int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gemv(device_queue->val, convert(trans), m, n,
+                                            static_cast<std::complex<double> >(alpha),
+                                            reinterpret_cast<const std::complex<double> *>(a), lda,
+                                            reinterpret_cast<const std::complex<double> *>(x), incx,
+                                            static_cast<std::complex<double> >(beta),
+                                            reinterpret_cast<std::complex<double> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklSger(syclQueue_t device_queue, int64_t m, int64_t n, float alpha,
+                           const float *x, int64_t incx, const float *y, int64_t incy,
+                           float *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::ger(device_queue->val, m, n, alpha, x,
+                                                    incx, y, incy, a, lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDger(syclQueue_t device_queue, int64_t m, int64_t n, double alpha,
+                           const double *x, int64_t incx, const double *y, int64_t incy,
+                           double *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::ger(device_queue->val, m, n, alpha, x,
+                                                    incx, y, incy, a, lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCgerc(syclQueue_t device_queue, int64_t m, int64_t n, float _Complex alpha,
+                           const float _Complex *x, int64_t incx, const float _Complex *y, int64_t incy,
+                           float _Complex *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::gerc(device_queue->val, m, n,
+                                            static_cast<std::complex<float> >(alpha),
+                                            reinterpret_cast<const std::complex<float> *>(x), incx,
+                                            reinterpret_cast<const std::complex<float> *>(y), incy,
+                                            reinterpret_cast<std::complex<float> *>(a), lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZgerc(syclQueue_t device_queue, int64_t m, int64_t n, double _Complex alpha,
+                           const double _Complex *x, int64_t incx, const double _Complex *y, int64_t incy,
+                           double _Complex *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::gerc(device_queue->val, m, n,
+                                          static_cast<std::complex<float> >(alpha),
+                                          reinterpret_cast<const std::complex<double> *>(x), incx,
+                                          reinterpret_cast<const std::complex<double> *>(y), incy,
+                                          reinterpret_cast<std::complex<double> *>(a), lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklChemv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                            float _Complex alpha, const float _Complex *a, int64_t lda,
+                            const float _Complex *x, int64_t incx, float _Complex beta,
+                            float _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::hemv(device_queue->val, convert(uplo), n,
+                                          static_cast<std::complex<float> >(alpha),
+                                          reinterpret_cast<const std::complex<float> *>(a),
+                                          lda, reinterpret_cast<const std::complex<float> *>(x), incx,
+                                          static_cast<std::complex<float> >(beta),
+                                          reinterpret_cast<std::complex<float> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZhemv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                            double _Complex alpha, const double _Complex *a, int64_t lda,
+                            const double _Complex *x, int64_t incx, double _Complex beta,
+                            double _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::hemv(device_queue->val, convert(uplo), n,
+                                          static_cast<std::complex<double> >(alpha),
+                                          reinterpret_cast<const std::complex<double> *>(a),
+                                          lda, reinterpret_cast<const std::complex<double> *>(x), incx,
+                                          static_cast<std::complex<double> >(beta),
+                                          reinterpret_cast<std::complex<double> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklChbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                            int64_t k, float _Complex alpha, const float _Complex *a,
+                            int64_t lda, const float _Complex *x, int64_t incx, float _Complex beta,
+                            float _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::hbmv(device_queue->val, convert(uplo), n,
+                                          k, static_cast<std::complex<float> >(alpha),
+                                          reinterpret_cast<const std::complex<float> *>(a),
+                                          lda, reinterpret_cast<const std::complex<float> *>(x),
+                                          incx, static_cast<std::complex<float> >(beta),
+                                          reinterpret_cast<std::complex<float> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZhbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                            int64_t k, double _Complex alpha, const double _Complex *a,
+                            int64_t lda, const double _Complex *x, int64_t incx, double _Complex beta,
+                            double _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::hbmv(device_queue->val, convert(uplo), n,
+                                          k, static_cast<std::complex<double> >(alpha),
+                                          reinterpret_cast<const std::complex<double> *>(a),
+                                          lda, reinterpret_cast<const std::complex<double> *>(x),
+                                          incx, static_cast<std::complex<double> >(beta),
+                                          reinterpret_cast<std::complex<double> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCher(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float alpha,
+                           const float _Complex *x, int64_t incx, float _Complex *a,
+                           int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::her(device_queue->val, convert(uplo), n, alpha,
+                                        reinterpret_cast<const std::complex<float> *>(x), incx,
+                                        reinterpret_cast<std::complex<float> *>(a), lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZher(syclQueue_t device_queue, onemklUplo uplo, int64_t n, double alpha,
+                           const double _Complex *x, int64_t incx, double _Complex *a,
+                           int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::her(device_queue->val, convert(uplo), n, alpha,
+                                        reinterpret_cast<const std::complex<double> *>(x), incx,
+                                        reinterpret_cast<std::complex<double> *>(a), lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCher2(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float _Complex alpha,
+                            const float _Complex *x, int64_t incx, const float _Complex *y, int64_t incy,
+                            float _Complex *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::her2(device_queue->val, convert(uplo), n,
+                                          static_cast<std::complex<float> >(alpha),
+                                          reinterpret_cast<const std::complex<float> *>(x), incx,
+                                          reinterpret_cast<const std::complex<float> *>(y), incy,
+                                          reinterpret_cast<std::complex<float> *>(a), lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZher2(syclQueue_t device_queue, onemklUplo uplo, int64_t n, double _Complex alpha,
+                            const double _Complex *x, int64_t incx, const double _Complex *y, int64_t incy,
+                            double _Complex *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::her2(device_queue->val, convert(uplo), n,
+                                          static_cast<std::complex<double> >(alpha),
+                                          reinterpret_cast<const std::complex<double> *>(x), incx,
+                                          reinterpret_cast<const std::complex<double> *>(y), incy,
+                                          reinterpret_cast<std::complex<double> *>(a), lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklSsbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n, int64_t k,
+                            float alpha, const float *a, int64_t lda, const float *x,
+                            int64_t incx, float beta, float *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::sbmv(device_queue->val, convert(uplo), n, k,
+                                                    alpha, a, lda, x, incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDsbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n, int64_t k,
+                            double alpha, const double *a, int64_t lda, const double *x,
+                            int64_t incx, double beta, double *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::sbmv(device_queue->val, convert(uplo), n, k,
+                                                    alpha, a, lda, x, incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklSsymv(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float alpha,
+                            const float *a, int64_t lda, const float *x, int64_t incx, float beta,
+                            float *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::symv(device_queue->val, convert(uplo), n, alpha,
+                                                    a, lda, x, incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDsymv(syclQueue_t device_queue, onemklUplo uplo, int64_t n, double alpha,
+                            const double *a, int64_t lda, const double *x, int64_t incx, double beta,
+                            double *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::symv(device_queue->val, convert(uplo), n, alpha,
+                                                    a, lda, x, incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklSsyr(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float alpha,
+                           const float *x, int64_t incx, float *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::syr(device_queue->val, convert(uplo), n, alpha,
+                                                    x, incx, a, lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDsyr(syclQueue_t device_queue, onemklUplo uplo, int64_t n, double alpha,
+                           const double *x, int64_t incx, double *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::syr(device_queue->val, convert(uplo), n, alpha,
+                                                    x, incx, a, lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklStbmv(syclQueue_t device_queue, onemklUplo uplo,
+                            onemklTranspose trans, onemklDiag diag, int64_t n,
+                            int64_t k, const float *a, int64_t lda, float *x, int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::tbmv(device_queue->val, convert(uplo), convert(trans),
+                                                        convert(diag), n, k, a, lda, x, incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDtbmv(syclQueue_t device_queue, onemklUplo uplo,
+                            onemklTranspose trans, onemklDiag diag, int64_t n,
+                            int64_t k, const double *a, int64_t lda, double *x, int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::tbmv(device_queue->val, convert(uplo), convert(trans),
+                                                    convert(diag), n, k, a, lda, x, incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCtbmv(syclQueue_t device_queue, onemklUplo uplo,
+                            onemklTranspose trans, onemklDiag diag, int64_t n,
+                            int64_t k, const float _Complex *a, int64_t lda, float _Complex *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::tbmv(device_queue->val, convert(uplo), convert(trans),
+                                            convert(diag), n, k, reinterpret_cast<const std::complex<float> *>(a),
+                                            lda, reinterpret_cast<std::complex<float> *>(x), incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZtbmv(syclQueue_t device_queue, onemklUplo uplo,
+                            onemklTranspose trans, onemklDiag diag, int64_t n,
+                            int64_t k, const double _Complex *a, int64_t lda, double _Complex *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::tbmv(device_queue->val, convert(uplo), convert(trans),
+                                        convert(diag), n, k, reinterpret_cast<const std::complex<double> *>(a),
+                                        lda, reinterpret_cast<std::complex<double> *>(x), incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+// trmv - level2
+extern "C" void onemklStrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const float *a, int64_t lda, float *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trmv(device_queue->val, convert(uplo), convert(trans),
+                                        convert(diag), n, a, lda, x, incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDtrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const double *a, int64_t lda, double *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trmv(device_queue->val, convert(uplo), convert(trans),
+                                        convert(diag), n, a, lda, x, incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCtrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const float _Complex *a, int64_t lda, float _Complex *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trmv(device_queue->val, convert(uplo), convert(trans),
+                                        convert(diag), n, reinterpret_cast<const std::complex<float> *>(a),
+                                        lda, reinterpret_cast<std::complex<float> *>(x), incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZtrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const double _Complex *a, int64_t lda, double _Complex *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trmv(device_queue->val, convert(uplo), convert(trans),
+                                        convert(diag), n, reinterpret_cast<const std::complex<double> *>(a),
+                                        lda, reinterpret_cast<std::complex<double> *>(x), incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+// trsv
+extern "C" void onemklStrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const float *a, int64_t lda, float *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trsv(device_queue->val, convert(uplo), convert(trans),
+                                          convert(diag), n, a, lda, x, incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDtrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const double *a, int64_t lda, double *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trsv(device_queue->val, convert(uplo), convert(trans),
+                                          convert(diag), n, a, lda, x, incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCtrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const float  _Complex *a, int64_t lda,
+                            float _Complex *x, int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trsv(device_queue->val, convert(uplo), convert(trans),
+                                          convert(diag), n, reinterpret_cast<const std::complex<float> *>(a),
+                                          lda, reinterpret_cast<std::complex<float> *>(x), incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZtrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const double _Complex *a, int64_t lda,
+                            double _Complex *x, int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trsv(device_queue->val, convert(uplo), convert(trans),
+                                          convert(diag), n, reinterpret_cast<const std::complex<double> *>(a),
+                                          lda, reinterpret_cast<std::complex<double> *>(x), incx);
     __FORCE_MKL_FLUSH__(status);
 }
 

--- a/library/src/oneApi_detail/deps/onemkl.h
+++ b/library/src/oneApi_detail/deps/onemkl.h
@@ -19,6 +19,16 @@ typedef enum {
     ONEMLK_TRANSPOSE_CONJTRANS
 } onemklTranspose;
 
+typedef enum {
+    ONEMKL_UPLO_UPPER,
+    ONEMKL_UPLO_LOWER
+} onemklUplo;
+
+typedef enum {
+    ONEMKL_DIAG_NONUNIT,
+    ONEMKL_DIAG_UNIT
+ } onemklDiag;
+
 // XXX: how to expose half in C?
 // int onemklHgemm(syclQueue_t device_queue, onemklTranspose transA,
 //                onemklTranspose transB, int64_t m, int64_t n, int64_t k,

--- a/library/src/oneApi_detail/deps/onemkl.h
+++ b/library/src/oneApi_detail/deps/onemkl.h
@@ -43,6 +43,51 @@ int onemklZgemm(syclQueue_t device_queue, onemklTranspose transA,
                 const double _Complex *B, int64_t ldb, double _Complex beta,
                 double _Complex *C, int64_t ldc);
 
+void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                int64_t n, int64_t kl, int64_t ku, float alpha, const float *a,
+                int64_t lda, const float *x, int64_t incx, float beta, float *y,
+                int64_t incy);
+void onemklDgbmv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                int64_t n, int64_t kl, int64_t ku, double alpha, const double *a,
+                int64_t lda, const double *x, int64_t incx, double beta, double *y,
+                int64_t incy);
+void onemklCgbmv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                int64_t n, int64_t kl, int64_t ku, float _Complex alpha, const float
+                _Complex *a, int64_t lda, const float _Complex *x, int64_t incx,
+                float _Complex beta, float _Complex *y, int64_t incy);
+void onemklZgbmv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                int64_t n, int64_t kl, int64_t ku, double _Complex alpha,
+                const double _Complex *a, int64_t lda, const double _Complex *x,
+                int64_t incx, double _Complex beta, double _Complex *y, int64_t incy);
+
+void onemklSgemv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                 int64_t n, float alpha, const float *a, int64_t lda,
+                 const float *x, int64_t incx, float beta, float *y, int64_t incy);
+void onemklDgemv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                 int64_t n, double alpha, const double *a, int64_t lda,
+                 const double *x, int64_t incx, double beta, double *y, int64_t incy);
+void onemklCgemv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                 int64_t n, float _Complex alpha, const float _Complex *a, int64_t lda,
+                 const float _Complex *x, int64_t incx, float _Complex beta,
+                 float _Complex *y, int64_t incy);
+void onemklZgemv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                 int64_t n, double _Complex alpha, const double _Complex *a, int64_t lda,
+                 const double _Complex *x, int64_t incx, double _Complex beta,
+                 double _Complex *y, int64_t incy);
+
+void onemklSger(syclQueue_t device_queue, int64_t m, int64_t n, float alpha,
+                const float *x, int64_t incx, const float *y, int64_t incy,
+                float *a, int64_t lda);
+void onemklDger(syclQueue_t device_queue, int64_t m, int64_t n, double alpha,
+                const double *x, int64_t incx, const double *y, int64_t incy,
+                double *a, int64_t lda);
+void onemklCgerc(syclQueue_t device_queue, int64_t m, int64_t n, float _Complex alpha,
+                const float _Complex *x, int64_t incx, const float _Complex *y, int64_t incy,
+                float _Complex *a, int64_t lda);
+void onemklZgerc(syclQueue_t device_queue, int64_t m, int64_t n, double _Complex alpha,
+                const double _Complex *x, int64_t incx, const double _Complex *y, int64_t incy,
+                double _Complex *a, int64_t lda);
+
 void onemklSasum(syclQueue_t device_queue, int64_t n,
                 const float *x, int64_t incx, float *result);
 void onemklDasum(syclQueue_t device_queue, int64_t n,
@@ -74,6 +119,103 @@ void onemklZscal(syclQueue_t device_queue, int64_t n, double _Complex alpha,
                 double _Complex *x, int64_t incx);
 void onemklZdscal(syclQueue_t device_queue, int64_t n, double alpha,
                 double _Complex *x, int64_t incx);
+
+void onemklChemv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                float _Complex alpha, const float _Complex *a, int64_t lda,
+                const float _Complex *x, int64_t incx, float _Complex beta,
+                float _Complex *y, int64_t incy);
+void onemklZhemv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                double _Complex alpha, const double _Complex *a, int64_t lda,
+                const double _Complex *x, int64_t incx, double _Complex beta,
+                double _Complex *y, int64_t incy);
+void onemklChbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                int64_t k, float _Complex alpha, const float _Complex *a,
+                int64_t lda, const float _Complex *x, int64_t incx, float _Complex beta,
+                float _Complex *y, int64_t incy);
+void onemklZhbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                int64_t k, double _Complex alpha, const double _Complex *a,
+                int64_t lda, const double _Complex *x, int64_t incx, double _Complex beta,
+                double _Complex *y, int64_t incy);
+void onemklCher(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float alpha,
+                const float _Complex *x, int64_t incx, float _Complex *a,
+                int64_t lda);
+void onemklZher(syclQueue_t device_queue, onemklUplo uplo, int64_t n, double alpha,
+                const double _Complex *x, int64_t incx, double _Complex *a,
+                int64_t lda);
+void onemklCher2(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float _Complex alpha,
+                const float _Complex *x, int64_t incx, const float _Complex *y, int64_t incy,
+                float _Complex *a, int64_t lda);
+void onemklZher2(syclQueue_t device_queue, onemklUplo uplo, int64_t n, double _Complex alpha,
+                const double _Complex *x, int64_t incx, const double _Complex *y, int64_t incy,
+                double _Complex *a, int64_t lda);
+
+void onemklSsbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n, int64_t k,
+                 float alpha, const float *a, int64_t lda, const float *x,
+                 int64_t incx, float beta, float *y, int64_t incy);
+void onemklDsbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n, int64_t k,
+                 double alpha, const double *a, int64_t lda, const double *x,
+                 int64_t incx, double beta, double *y, int64_t incy);
+void onemklSsymv(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float alpha,
+                 const float *a, int64_t lda, const float *x, int64_t incx, float beta,
+                 float *y, int64_t incy);
+void onemklDsymv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                 double alpha, const double *a, int64_t lda, const double *x,
+                 int64_t incx, double beta, double *y, int64_t incy);
+void onemklSsyr(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float alpha,
+                           const float *x, int64_t incx, float *a, int64_t lda);
+void onemklDsyr(syclQueue_t device_queue, onemklUplo uplo, int64_t n, double alpha,
+                           const double *x, int64_t incx, double *a, int64_t lda);
+void onemklStbmv(syclQueue_t device_queue, onemklUplo uplo,
+                onemklTranspose trans, onemklDiag diag, int64_t n,
+                int64_t k, const float *a, int64_t lda, float *x, int64_t incx);
+
+void onemklDtbmv(syclQueue_t device_queue, onemklUplo uplo,
+                onemklTranspose trans, onemklDiag diag, int64_t n,
+                int64_t k, const double *a, int64_t lda, double *x, int64_t incx);
+
+void onemklCtbmv(syclQueue_t device_queue, onemklUplo uplo,
+                onemklTranspose trans, onemklDiag diag, int64_t n,
+                int64_t k, const float _Complex *a, int64_t lda, float _Complex *x,
+                int64_t incx);
+
+void onemklZtbmv(syclQueue_t device_queue, onemklUplo uplo,
+                onemklTranspose trans, onemklDiag diag, int64_t n,
+                int64_t k, const double _Complex *a, int64_t lda, double _Complex *x,
+                int64_t incx);
+
+void onemklStrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const float *a, int64_t lda, float *x,
+                int64_t incx);
+
+void onemklDtrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const double *a, int64_t lda, double *x,
+                int64_t incx);
+
+void onemklCtrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const float _Complex *a, int64_t lda, float _Complex *x,
+                int64_t incx);
+
+void onemklZtrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const double _Complex *a, int64_t lda, double _Complex *x,
+                int64_t incx);
+
+// trsv
+void onemklStrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const float *a, int64_t lda, float *x,
+                int64_t incx);
+
+void onemklDtrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const double *a, int64_t lda, double *x,
+                int64_t incx);
+
+void onemklCtrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const float _Complex *a, int64_t lda, float _Complex *x,
+                int64_t incx);
+
+void onemklZtrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const double _Complex *a, int64_t lda, double _Complex *x,
+                int64_t incx);
+
 // Supported Level-1: Nrm2
 void onemklDnrm2(syclQueue_t device_queue, int64_t n, const double *x,
                  int64_t incx, double *result);
@@ -83,6 +225,23 @@ void onemklCnrm2(syclQueue_t device_queue, int64_t n, const float _Complex *x,
                  int64_t incx, float *result);
 void onemklZnrm2(syclQueue_t device_queue, int64_t n, const double _Complex *x,
                  int64_t incx, double *result);
+
+void onemklSdot(syclQueue_t device_queue, int64_t n, const float *x,
+                int64_t incx, const float *y, int64_t incy, float *result);
+void onemklDdot(syclQueue_t device_queue, int64_t n, const double *x,
+                int64_t incx, const double *y, int64_t incy, double *result);
+void onemklCdotc(syclQueue_t device_queue, int64_t n, const float _Complex *x,
+                int64_t incx, const float _Complex *y, int64_t incy,
+                float _Complex *result);
+void onemklZdotc(syclQueue_t device_queue, int64_t n, const double _Complex *x,
+                int64_t incx, const double _Complex *y, int64_t incy,
+                double _Complex *result);
+void onemklCdotu(syclQueue_t device_queue, int64_t n, const float _Complex *x,
+                int64_t incx, const float _Complex *y, int64_t incy,
+                float _Complex *result);
+void onemklZdotu(syclQueue_t device_queue, int64_t n, const double _Complex *x,
+                int64_t incx, const double _Complex *y, int64_t incy,
+                double _Complex *result);
 
 void onemklDcopy(syclQueue_t device_queue, int64_t n, const double *x,
                  int64_t incx, double *y, int64_t incy);

--- a/library/src/oneApi_detail/hipblas.cpp
+++ b/library/src/oneApi_detail/hipblas.cpp
@@ -121,7 +121,7 @@ catch(...)
 // Generic amax which can handle batched/stride/non-batched
 hipblasStatus_t ihipblasIsamax(hipblasHandle_t handle, int n, const float* x, int incx, int batchCount, int* results) {
     int64_t *dev_results = nullptr;
-    hipError_t hip_status = hipMalloc(&dev_result, sizeof(int64_t)*batchCount);
+    hipError_t hip_status = hipMalloc(&dev_results, sizeof(int64_t)*batchCount);
 
     auto sycl_queue = syclblas_get_sycl_queue((syclblasHandle_t)handle);
     for (int i=0; i<batchCount; ++i) {
@@ -130,7 +130,7 @@ hipblasStatus_t ihipblasIsamax(hipblasHandle_t handle, int n, const float* x, in
     syclblas_queue_wait(sycl_queue); // wait until task is completed
 
     int64_t* results_host_memory = (int64_t*)malloc(sizeof(int64_t)*batchCount);
-    hip_status = hipMemcpy(results_host_memory, dev_result, sizeof(int)*batchCount, hipMemcpyDefault);
+    hip_status = hipMemcpy(results_host_memory, dev_results, sizeof(int)*batchCount, hipMemcpyDefault);
 
     //Fix_Me : Chance of data corruption
     for (auto i=0; i<batchCount; ++i) {
@@ -232,9 +232,9 @@ try
 {
     // As per spec alpha can be device/host memory. In case of device memory *alpha will crash
     float host_alpha = 0;
-    hipMemcpy(&host_alpha, alpha, sizeof(float), hipMemcpyDefault);
+    auto staus = hipMemcpy(&host_alpha, alpha, sizeof(float), hipMemcpyDefault);
 
-    onemklSscal(syclblasGetSyclQueue((syclblasHandle_t)handle), n, host_alpha, x, incx);
+    onemklSscal(syclblas_get_sycl_queue((syclblasHandle_t)handle), n, host_alpha, x, incx);
     return HIPBLAS_STATUS_SUCCESS;
 }
 catch(...)
@@ -248,9 +248,9 @@ try
 {
     // As per spec alpha can be device/host memory. In case of device memory *alpha will crash
     double host_alpha = 0;
-    hipMemcpy(&host_alpha, alpha, sizeof(double), hipMemcpyDefault);
+    auto status = hipMemcpy(&host_alpha, alpha, sizeof(double), hipMemcpyDefault);
     
-    onemklSscal(syclblasGetSyclQueue((syclblasHandle_t)handle), n, host_alpha, x, incx);
+    onemklDscal(syclblas_get_sycl_queue((syclblasHandle_t)handle), n, host_alpha, x, incx);
     return HIPBLAS_STATUS_SUCCESS;
 }
 catch(...)
@@ -262,9 +262,9 @@ hipblasStatus_t
     hipblasSasum(hipblasHandle_t handle, int n, const float* x, int incx, float* result)
 try
 {
-    auto sycl_queue = syclblasGetSyclQueue((syclblasHandle_t)handle);
+    auto sycl_queue = syclblas_get_sycl_queue((syclblasHandle_t)handle);
     float* dev_result = nullptr;
-    hipError_t status = hipMalloc(dev_result, sizeof(float));
+    hipError_t status = hipMalloc(&dev_result, sizeof(float));
     onemklSasum(sycl_queue, n, x, incx, dev_result);
     syclblas_queue_wait(sycl_queue); // wait until task is completed
     status = hipMemcpy(result, dev_result, sizeof(float), hipMemcpyDefault);
@@ -281,9 +281,9 @@ hipblasStatus_t
     hipblasDasum(hipblasHandle_t handle, int n, const double* x, int incx, double* result)
 try
 {
-    auto sycl_queue = syclblasGetSyclQueue((syclblasHandle_t)handle);
+    auto sycl_queue = syclblas_get_sycl_queue((syclblasHandle_t)handle);
     double* dev_result = nullptr;
-    hipError_t status = hipMalloc(dev_result, sizeof(double));
+    hipError_t status = hipMalloc(&dev_result, sizeof(double));
     onemklDasum(sycl_queue, n, x, incx, dev_result);
     syclblas_queue_wait(sycl_queue); // wait until task is completed
 


### PR DESCRIPTION
Summary of proposed changes:

What is new?

Added some of level1 APIs for hipBlas. These are APIs used by libCEED hence enabling them first.
Minor bug fixes
Some effort of clean-up
Test status : Passed on Ubuntu+Gen9